### PR TITLE
Graph date ranges and type switchers

### DIFF
--- a/src/components/views/dashboard/Overview.js
+++ b/src/components/views/dashboard/Overview.js
@@ -142,8 +142,11 @@ export default function Overview() {
           </div>
         </div>
         <OverviewChart
-          siteData={overallTimeSeries}
+          endDate={new Date()}
+          overviewData={overallTimeSeries}
           sites={sites}
+          sitesData={sitesGraphData}
+          startDate={new Date(new Date().getTime() - timeIncrement)}
           timeIncrement={timeIncrement}
         />
         <OverviewSiteList

--- a/src/components/views/dashboard/OverviewChart.js
+++ b/src/components/views/dashboard/OverviewChart.js
@@ -14,6 +14,7 @@ import {
 } from '../../../services/search';
 import {
   formatXAxisLabels,
+  getFormattedTime,
   splitDayAndNightDataSets,
 } from '../../../utils/Utils';
 import { tooltipPlugin } from '../../common/graphPlugins';
@@ -29,14 +30,6 @@ export default function OverviewChart({
   const [dayData, setDayData] = useState([]);
   const [nightData, setNightData] = useState([]);
   const [graphType, setGraphType] = useState('overview');
-
-  const dateFormat = {
-    year: '2-digit',
-    month: 'numeric',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  };
 
   useEffect(() => {
     if (overviewData == null) {
@@ -224,8 +217,7 @@ export default function OverviewChart({
     <div className='OverviewChart mb-6 w-full rounded-lg bg-brand-primary-light p-3'>
       <div className='mb-2 flex items-center justify-between'>
         <div className='text-xs'>
-          {startDate.toLocaleString([], dateFormat)} -{' '}
-          {endDate.toLocaleString([], dateFormat)}
+          {getFormattedTime(startDate)} - {getFormattedTime(endDate)}
         </div>
         <div className='flex items-center rounded border bg-white'>
           <button

--- a/src/components/views/site-details/SiteDetails.js
+++ b/src/components/views/site-details/SiteDetails.js
@@ -164,9 +164,11 @@ export default function SiteDetails() {
         </div>
         <SiteDetailsGraph
           deviceNames={devices.map((d) => getDisplayName(d))}
+          endDate={new Date()}
           graphData={graphData}
           graphType={graphType}
           setGraphType={setGraphTypeWrapper}
+          startDate={new Date(new Date().getTime() - timeIncrement)}
           timeIncrement={timeIncrement}
         />
         <SiteDevicesOverview

--- a/src/components/views/site-details/SiteDetailsGraph.js
+++ b/src/components/views/site-details/SiteDetailsGraph.js
@@ -16,7 +16,17 @@ export default function SiteDetailsGraph({
   graphType,
   setGraphType,
   timeIncrement,
+  startDate,
+  endDate,
 }) {
+  const dateFormat = {
+    year: '2-digit',
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  };
+
   const datasets = deviceNames.map((name) => {
     const data = graphData.filter((d) => d.name === name);
     const dataSet = {
@@ -51,6 +61,9 @@ export default function SiteDetailsGraph({
       },
     },
     plugins: {
+      legend: {
+        position: 'bottom',
+      },
       tooltip: {
         backgroundColor: '#fff',
         titleColor: '#000',
@@ -94,8 +107,7 @@ export default function SiteDetailsGraph({
         min: 0,
         stacked: graphType !== GROUPED_BAR,
         title: {
-          display: true,
-          text: 'kW',
+          display: false,
         },
       },
     },
@@ -111,34 +123,40 @@ export default function SiteDetailsGraph({
   return (
     <>
       <div className='SiteDetailsGraph group relative mb-6 w-full rounded-lg bg-brand-primary-light p-3'>
-        <div className='relative right-2 top-2 mb-4 ml-auto flex w-fit rounded border bg-white duration-150 sm:absolute sm:mb-0 sm:opacity-25 sm:transition-opacity sm:group-hover:opacity-100'>
-          <button
-            aria-label='grouped bar graph'
-            className={classNames('border-r p-2 hover:bg-neutral-200', {
-              'bg-neutral-300': graphType === GROUPED_BAR,
-            })}
-            onClick={() => setGraphType(GROUPED_BAR)}
-          >
-            <MdBarChart className='text-brand-primary-dark text-xl' />
-          </button>
-          <button
-            aria-label='bar graph'
-            className={classNames('p-2 hover:bg-neutral-200', {
-              'bg-neutral-300': graphType === 'bar',
-            })}
-            onClick={() => setGraphType('bar')}
-          >
-            <MdStackedBarChart className='text-brand-primary-dark text-xl' />
-          </button>
-          <button
-            aria-label='line graph'
-            className={classNames('border-l p-2 hover:bg-neutral-200', {
-              'bg-neutral-300': graphType === 'line',
-            })}
-            onClick={() => setGraphType('line')}
-          >
-            <MdStackedLineChart className='text-brand-primary-dark text-xl' />
-          </button>
+        <div className='flex items-center justify-between'>
+          <div className='text-xs'>
+            {startDate.toLocaleString([], dateFormat)} -{' '}
+            {endDate.toLocaleString([], dateFormat)}
+          </div>
+          <div className='flex w-fit rounded border bg-white duration-150'>
+            <button
+              aria-label='site stacked line graph'
+              className={classNames('border-r px-2 py-1 hover:bg-neutral-200', {
+                'bg-neutral-300': graphType === GROUPED_BAR,
+              })}
+              onClick={() => setGraphType(GROUPED_BAR)}
+            >
+              <MdBarChart className='text-brand-primary-dark text-xl' />
+            </button>
+            <button
+              aria-label='site stacked bar graph'
+              className={classNames('px-2 py-1 hover:bg-neutral-200', {
+                'bg-neutral-300': graphType === 'bar',
+              })}
+              onClick={() => setGraphType('bar')}
+            >
+              <MdStackedBarChart className='text-brand-primary-dark text-xl' />
+            </button>
+            <button
+              aria-label='overview graph'
+              className={classNames('border-l px-2 py-1 hover:bg-neutral-200', {
+                'bg-neutral-300': graphType === 'line',
+              })}
+              onClick={() => setGraphType('line')}
+            >
+              <MdStackedLineChart className='text-brand-primary-dark text-xl' />
+            </button>
+          </div>
         </div>
         <div className='h-72'>
           {graphType === 'line' && (

--- a/src/components/views/site-details/SiteDetailsGraph.js
+++ b/src/components/views/site-details/SiteDetailsGraph.js
@@ -7,7 +7,11 @@ import {
 } from 'react-icons/md';
 
 import { DAY, GROUPED_BAR } from '../../../services/search';
-import { formatXAxisLabels } from '../../../utils/Utils';
+import {
+  formatXAxisLabels,
+  getFormattedDaysHoursMinutes,
+  getFormattedTime,
+} from '../../../utils/Utils';
 import { tooltipPlugin } from '../../common/graphPlugins';
 
 export default function SiteDetailsGraph({
@@ -19,13 +23,13 @@ export default function SiteDetailsGraph({
   startDate,
   endDate,
 }) {
-  const dateFormat = {
-    year: '2-digit',
-    month: 'numeric',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  };
+  // const dateFormat = {
+  //   year: '2-digit',
+  //   month: 'numeric',
+  //   day: 'numeric',
+  //   hour: '2-digit',
+  //   minute: '2-digit',
+  // };
 
   const datasets = deviceNames.map((name) => {
     const data = graphData.filter((d) => d.name === name);
@@ -125,8 +129,7 @@ export default function SiteDetailsGraph({
       <div className='SiteDetailsGraph group relative mb-6 w-full rounded-lg bg-brand-primary-light p-3'>
         <div className='flex items-center justify-between'>
           <div className='text-xs'>
-            {startDate.toLocaleString([], dateFormat)} -{' '}
-            {endDate.toLocaleString([], dateFormat)}
+            {getFormattedTime(startDate)} - {getFormattedTime(endDate)}
           </div>
           <div className='flex w-fit rounded border bg-white duration-150'>
             <button


### PR DESCRIPTION
fixes: https://github.com/bigboxer23/solar-moon-frontend/issues/164
fixes: https://github.com/bigboxer23/solar-moon-frontend/issues/156

Adds graph switcher to Overview. Adds graph date-range to Site-Overview and Overview graphs.

Next/Prev buttons will go to the left of the date range in a future PR.

Overview:

<img width="918" alt="Screenshot 2024-01-25 at 10 25 15 PM" src="https://github.com/bigboxer23/solar-moon-frontend/assets/12434857/bf0cf18e-3902-40df-bfe3-a81e334b9e47">

<img width="896" alt="Screenshot 2024-01-25 at 10 26 28 PM" src="https://github.com/bigboxer23/solar-moon-frontend/assets/12434857/38ad5e1f-e611-4cc6-9939-fbbc41240e3b">
