### PR TITLE
fix: react-select should not be necessary since we're only using the …

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-icons": "^4.11.0",
     "react-intl": "^6.5.5",
     "react-router-dom": "^6.16.0",
+    "react-select": "^5.8.0",
     "react-timezone-select": "^3.2.3",
     "react-toastify": "^9.1.3",
     "sass": "^1.69.5",


### PR DESCRIPTION
…hook from the timezone library, but it is failing to build w/o it.