### PR TITLE
fix: x axis labels should display time consistently across all graph …

### DIFF
--- a/src/components/views/dashboard/OverviewChart.js
+++ b/src/components/views/dashboard/OverviewChart.js
@@ -17,10 +17,10 @@ import {
 } from '../../../services/search';
 import {
   formatXAxisLabels,
+  formatXAxisLabelsDay,
   getFormattedTime,
   maybeSetTimeWindow,
   roundTwoDigit,
-  splitDayAndNightDataSets,
   timeLabel,
   useStickyState,
 } from '../../../utils/Utils';
@@ -80,7 +80,8 @@ export default function OverviewChart({
         type: 'time',
         ticks: {
           stepSize: 6,
-          callback: timeIncrement === DAY ? null : formatXAxisLabels,
+          callback:
+            timeIncrement === DAY ? formatXAxisLabelsDay : formatXAxisLabels,
         },
       },
       y: {
@@ -143,11 +144,7 @@ export default function OverviewChart({
         ticks: {
           stepSize: 6,
           callback:
-            timeIncrement === DAY
-              ? (value) => {
-                  return format(value, 'h:mmaaaaa');
-                }
-              : formatXAxisLabels,
+            timeIncrement === DAY ? formatXAxisLabelsDay : formatXAxisLabels,
         },
       },
       y: {

--- a/src/components/views/site-details/SiteDetailsGraph.js
+++ b/src/components/views/site-details/SiteDetailsGraph.js
@@ -13,6 +13,7 @@ import {
 import { DAY, GROUPED_BAR } from '../../../services/search';
 import {
   formatXAxisLabels,
+  formatXAxisLabelsDay,
   getDisplayName,
   getFormattedTime,
   maybeSetTimeWindow,
@@ -105,7 +106,8 @@ export default function SiteDetailsGraph({
         stacked: graphType !== GROUPED_BAR,
         type: 'time',
         ticks: {
-          callback: timeIncrement === DAY ? null : formatXAxisLabels,
+          callback:
+            timeIncrement === DAY ? formatXAxisLabelsDay : formatXAxisLabels,
         },
       },
       y: {

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -68,6 +68,10 @@ export const getFormattedDate = (date) => {
   return format(date, 'MMM d, yy');
 };
 
+export const formatXAxisLabelsDay = (value) => {
+  return format(value, 'h:mmaaaaa');
+};
+
 export const formatXAxisLabels = (value, index, ticks) => {
   const d = new Date(value);
   if (d.getHours() % 6 !== 0 || d.getMinutes() !== 0) {


### PR DESCRIPTION
…scopes (site, overview) and types