### PR TITLE
fix: if search is active on report or alerts page and page is refresh…

### DIFF
--- a/src/components/views/alerts/AlertsFilter.js
+++ b/src/components/views/alerts/AlertsFilter.js
@@ -33,7 +33,9 @@ export default function AlertsFilter({
 
   const defaultEnd = searchParamEnd ? new Date(searchParamEnd) : null;
 
-  const [dirty, setDirty] = useState(false);
+  const [dirty, setDirty] = useState(
+    searchParamSite != null || searchParamDevice != null,
+  );
 
   const [siteIdValue, setSiteIdValue] = useState(defaultSite);
   const [deviceIdValue, setDeviceIdValue] = useState(defaultDevice);

--- a/src/components/views/reports/SearchBar.js
+++ b/src/components/views/reports/SearchBar.js
@@ -39,7 +39,9 @@ const SearchBar = ({
   refreshSearch,
   setRefreshSearch,
 }) => {
-  const [searchActive, setSearchActive] = useState(false);
+  const [searchActive, setSearchActive] = useState(
+    deviceId !== ALL || siteId !== ALL,
+  );
 
   const [value, setValue] = useState([
     new Date(Number(start)),


### PR DESCRIPTION
…ed, should load page in "active search" state