### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to S3
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bigboxer23/solar-moon-frontend/security/code-scanning/2](https://github.com/bigboxer23/solar-moon-frontend/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block to the workflow or job definition, specifying the minimal set of privileges required. In this case, the workflow checks out code but does not appear to require any write access to the repository (it only reads code and deploys to AWS). Therefore, setting `contents: read` as the job or workflow-level permission is appropriate and follows the principle of least privilege.

To implement this:
- Add the following block near the top-level of the workflow file (just below `name:` and before `on:`):  
  ```yaml
  permissions:
    contents: read
  ```
  This will apply to all jobs in the workflow, unless overridden.
- No imports or definitions are necessary; this is strictly a configuration change within the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
